### PR TITLE
OAuth FiPNA Enhancements

### DIFF
--- a/draft-parecki-oauth-first-party-native-apps.md
+++ b/draft-parecki-oauth-first-party-native-apps.md
@@ -443,7 +443,7 @@ In a traditional OAuth deployment using the redirect-based authorization code fl
 Because of these risks, the authorization server MAY decide to require that the user go through a redirect-based flow at any stage of the process based on its own risk assessment.
 
 
-## Credential Attacks {#credential-attacks}
+## Credential Stuffing Attacks {#credential-attacks}
 
 The authorization challenge endpoint is capable of directly receiving user credentials and returning authorization codes. This exposes a new vector to perform credential attacks. 
 

--- a/draft-parecki-oauth-first-party-native-apps.md
+++ b/draft-parecki-oauth-first-party-native-apps.md
@@ -372,9 +372,17 @@ The client MUST include the device session in future requests to the authorizati
 
 ## Authorization Challenge Grant - Client Metadata
 
-This specification introduces a new OAuth 'grant_type' named 'authz_challenge' to the client metadata{{RFC7591}}. This grant enables the authorization server to identify if a client is authorized to use the authorization challenge flow. In order to reduce the risk of unauthorized client use, and, attackers from abusing the authorization challenge endpoint, this grant type MUST only be issued to first party app clients.
+This specification introduces a new OAuth 'grant_type' named 'authz_challenge' to the client metadata{{RFC6749}}. This grant enables the authorization server to identify if a client is authorized to use the authorization challenge flow. In order to reduce the risk of unauthorized client use, and, attackers from abusing the authorization challenge endpoint, this grant type MUST only be issued to first party app clients.
 
 When a request is made to the `authorization_challenge_endpoint`, the authorization server MUST verify that the client has the authz_challenge grant type. The authorization server MUST reject requests made by clients which have not been assigned the authz_challenge grant type. 
+
+## Authorization Challenge Grant - Dynamic Client Registration
+
+An authorization server which has enabled first party applications to use the dynamic client registration endpoint{{RFC7591}} MAY allow first party clients to register for the "authz_challenge" Grant Type. The authorization server MUST NOT allow non first party apps to register with the authz_challenge Grant Type. When possible, the authorization server SHOULD require the use of OS attestation services to provide a level of confidence to the AS that the registration request is being made by an application owned by the first party. 
+
+Mechanisms for issuing this grant to existing clients are outside of the scope of this specification. 
+
+The security mechanisms to protect the dynamic client registration endpoint are outside of the scope of this specification. 
 
 # Token Request {#token-request}
 

--- a/draft-parecki-oauth-first-party-native-apps.md
+++ b/draft-parecki-oauth-first-party-native-apps.md
@@ -374,7 +374,7 @@ The client MUST include the device session in future requests to the authorizati
 
 This specification introduces a new OAuth 'grant_type' named 'authz_challenge' to the client metadata{{RFC6749}}. This grant enables the authorization server to identify if a client is authorized to use the authorization challenge flow. In order to reduce the risk of unauthorized client use, and, attackers from abusing the authorization challenge endpoint, this grant type MUST only be issued to first party app clients.
 
-When a request is made to the `authorization_challenge_endpoint`, the authorization server MUST verify that the client has the authz_challenge grant type. The authorization server MUST reject requests made by clients which have not been assigned the authz_challenge grant type. 
+When a request is made to the `authorization_challenge_endpoint`, the authorization server MUST validate that the client has been granted the authz_challenge grant type. The authorization server MUST reject requests made to the authorization challenge endpoint by clients which have not been assigned the authz_challenge grant type. 
 
 ## Authorization Challenge Grant - Dynamic Client Registration
 
@@ -459,9 +459,9 @@ Because of these risks, the authorization server MAY decide to require that the 
 
 ## Credential Attacks {#credential-attacks}
 
-The nature of moving from browser-based authentication to a backend API which is capable of directly receiving user credentials exposes a risk to attacks such as credential stuffing and brute forcing credentails to see if an authorization code is returned by the authorization challenge endpoint. An authorization server may already have a combination of built-in or 3rd party security tools in place to monitor and reduce this risk in the browser-based authentication.  
+The nature of moving from browser-based authentication to a backend API capable of directly receiving user credentials exposes a risk to attacks, such as credential stuffing and brute forcing credentails in an attempt to receive an authorization code. An authorization server may already have a combination of built-in or 3rd party security tools in place to monitor and reduce this risk in the browser-based authentication.  
 
-Implementors SHOULD consider additional security measures to reduce this risk in the authorization challenge endpoint such as monitoringing for suspicious activity. Additionally, the attestation APIs SHOUOLD be used when possible to assert a level of confidence to the authorization server that the request is originating from an application owned by the same party.
+Implementors SHOULD consider additional security measures to reduce this risk in the authorization challenge endpoint such as monitoringing for suspicious activity. Additionally, the attestation APIs SHOULD be used when possible to assert a level of confidence to the authorization server that the request is originating from an application owned by the same party.
 
 ## Client Authentication
 

--- a/draft-parecki-oauth-first-party-native-apps.md
+++ b/draft-parecki-oauth-first-party-native-apps.md
@@ -443,6 +443,12 @@ In a traditional OAuth deployment using the redirect-based authorization code fl
 Because of these risks, the authorization server MAY decide to require that the user go through a redirect-based flow at any stage of the process based on its own risk assessment.
 
 
+## Credential Attacks {#credential-attacks}
+
+The nature of moving from browser-based authentication to a backend API which is capable of directly receiving user credentials exposes a risk to attacks such as credential stuffing and brute forcing credentails to see if an authorization code is returned by the authorization challenge endpoint. An authorization server may already have a combination of built-in or 3rd party security tools in place to monitor and reduce this risk in the browser-based authentication.  
+
+Implementors SHOULD consider additional security measures to reduce this risk in the authorization challenge endpoint such as monitoringing for suspicious activity. Additionally, the attestation APIs SHOUOLD be used when possible to assert a level of confidence to the authorization server that the request is originating from an application owned by the same party.
+
 ## Client Authentication
 
 Typically, mobile and desktop applications are considered "public clients" in OAuth, since they cannot be shipped with a statically configured set of client credentials {{RFC8252}}. Because of this, client impersonation should be a concern of anyone deploying this pattern. Without client authentication, a malicious user or attacker can mimick the requests the application makes to the authorization server, pretending to be the legitimate client.
@@ -475,7 +481,7 @@ It may be possible to use other proof of possession mechanisms to sender constra
 When there is more than one 1st-party native applications supported by the AS, then it is important to consider a number of additional risks. These risks fall into two main categories: Experience Risk and Technical Risk which are described below.
 
 ### Experience Risk
-Any time a user is asked to provide the authentication credentials in user experiences that differ, it has the effect of increasing the likelihood that the user will fall prey to a phishing attack because they are used to entering credentials in different looking experiences. When multiple native applications are support, the implementation MUST ensure the native experience is identical across all the 1st party native applications.
+Any time a user is asked to provide the authentication credentials in user experiences that differ, it has the effect of increasing the likelihood that the user will fall prey to a phishing attack because they are used to entering credentials in different looking experiences. When multiple native applications are supported, the implementation MUST ensure the native experience is identical across all the 1st party native applications.
 
 Another experience risk is user confusion caused by different looking experiences and behaviors. This can increase the likelihood the user will not complete the authentication experience for the 1st party native application.
 

--- a/draft-parecki-oauth-first-party-native-apps.md
+++ b/draft-parecki-oauth-first-party-native-apps.md
@@ -370,20 +370,6 @@ The device session is completely opaque to the client, and as such the AS MUST a
 
 The client MUST include the device session in future requests to the authorization challenge endpoint for the particular authorization request.
 
-## Authorization Challenge Grant - Client Metadata
-
-This specification introduces a new OAuth 'grant_type' named 'authz_challenge' to the client metadata{{RFC6749}}. This grant enables the authorization server to identify if a client is authorized to use the authorization challenge flow. In order to reduce the risk of unauthorized client use, and, attackers from abusing the authorization challenge endpoint, this grant type MUST only be issued to first party app clients.
-
-When a request is made to the `authorization_challenge_endpoint`, the authorization server MUST validate that the client has been granted the authz_challenge grant type. The authorization server MUST reject requests made to the authorization challenge endpoint by clients which have not been assigned the authz_challenge grant type. 
-
-## Authorization Challenge Grant - Dynamic Client Registration
-
-An authorization server which has enabled first party applications to use the dynamic client registration endpoint{{RFC7591}} MAY allow first party clients to register for the "authz_challenge" Grant Type. The authorization server MUST NOT allow non first party apps to register with the authz_challenge Grant Type. When possible, the authorization server SHOULD require the use of OS attestation services to provide a level of confidence to the AS that the registration request is being made by an application owned by the first party. 
-
-Mechanisms for issuing this grant to existing clients are outside of the scope of this specification. 
-
-The security mechanisms to protect the dynamic client registration endpoint are outside of the scope of this specification. 
-
 # Token Request {#token-request}
 
 The client makes a request to the token endpoint using the authorization code it obtained from the authorization challenge endpoint.

--- a/draft-parecki-oauth-first-party-native-apps.md
+++ b/draft-parecki-oauth-first-party-native-apps.md
@@ -459,9 +459,9 @@ Because of these risks, the authorization server MAY decide to require that the 
 
 ## Credential Attacks {#credential-attacks}
 
-The nature of moving from browser-based authentication to a backend API capable of directly receiving user credentials exposes a risk to attacks, such as credential stuffing and brute forcing credentails in an attempt to receive an authorization code. An authorization server may already have a combination of built-in or 3rd party security tools in place to monitor and reduce this risk in the browser-based authentication.  
+The authorization challenge endpoint is capable of directly receiving user credentials and returning authorization codes. This exposes a new vector to perform credential attacks. 
 
-Implementors SHOULD consider additional security measures to reduce this risk in the authorization challenge endpoint such as monitoringing for suspicious activity. Additionally, the attestation APIs SHOULD be used when possible to assert a level of confidence to the authorization server that the request is originating from an application owned by the same party.
+An authorization server may already have a combination of built-in or 3rd party security tools in place to monitor and reduce this risk in browser-based authentication flows. Implementors SHOULD consider similar security measures to reduce this risk in the authorization challenge endpoint. Additionally, the attestation APIs SHOULD be used when possible to assert a level of confidence to the authorization server that the request is originating from an application owned by the same party.
 
 ## Client Authentication
 

--- a/draft-parecki-oauth-first-party-native-apps.md
+++ b/draft-parecki-oauth-first-party-native-apps.md
@@ -370,6 +370,12 @@ The device session is completely opaque to the client, and as such the AS MUST a
 
 The client MUST include the device session in future requests to the authorization challenge endpoint for the particular authorization request.
 
+## Authorization Challenge Grant - Client Metadata
+
+This specification introduces a new OAuth 'grant_type' named 'authz_challenge' to the client metadata{{RFC7591}}. This grant enables the authorization server to identify if a client is authorized to use the authorization challenge flow. In order to reduce the risk of unauthorized client use, and, attackers from abusing the authorization challenge endpoint, this grant type MUST only be issued to first party app clients.
+
+When a request is made to the `authorization_challenge_endpoint`, the authorization server MUST verify that the client has the authz_challenge grant type. The authorization server MUST reject requests made by clients which have not been assigned the authz_challenge grant type. 
+
 # Token Request {#token-request}
 
 The client makes a request to the token endpoint using the authorization code it obtained from the authorization challenge endpoint.

--- a/draft-parecki-oauth-first-party-native-apps.md
+++ b/draft-parecki-oauth-first-party-native-apps.md
@@ -445,7 +445,7 @@ Because of these risks, the authorization server MAY decide to require that the 
 
 ## Credential Stuffing Attacks {#credential-attacks}
 
-The authorization challenge endpoint is capable of directly receiving user credentials and returning authorization codes. This exposes a new vector to perform credential attacks. 
+The authorization challenge endpoint is capable of directly receiving user credentials and returning authorization codes. This exposes a new vector to perform credential stuffing attacks, if additional measures are not taken to ensure the authenticity of the application. 
 
 An authorization server may already have a combination of built-in or 3rd party security tools in place to monitor and reduce this risk in browser-based authentication flows. Implementors SHOULD consider similar security measures to reduce this risk in the authorization challenge endpoint. Additionally, the attestation APIs SHOULD be used when possible to assert a level of confidence to the authorization server that the request is originating from an application owned by the same party.
 


### PR DESCRIPTION
I added three sections I feel are important:
1.) Credential Stuffing/Abuse callout in security considerations. Browser-based front ends have lots of security checks inherently built in to an IdP's flow. If we move the authNZ to be backend API based then it's important to call out to implementors that they should treat that API with the same security concerns as whatever API recieves request when a login form is submitted. 
2.) New Grant Type needed. 
3.) DCR Registration consideration
and 4.) corrected minor typo

Happy to discuss. I have other updates I'll add and submit PRs/issues for later. 